### PR TITLE
Update ModuleXNavigation.php

### DIFF
--- a/system/modules/xNavigation/ModuleXNavigation.php
+++ b/system/modules/xNavigation/ModuleXNavigation.php
@@ -45,6 +45,12 @@ class ModuleXNavigation extends Module {
 	protected $strTemplate = 'mod_navigation';
 
 	/**
+	* for active/trail CSS-Class for page
+	* @var bool
+	*/
+	public $isSubActive = false;
+	
+	/**
 	 * Do not display the module if there are no menu items
 	 * @return string
 	 */
@@ -174,6 +180,12 @@ class ModuleXNavigation extends Module {
 			
 			$arrItems[0]['class'] = trim($arrItems[0]['class'] . ' first');
 			$arrItems[$last]['class'] = trim($arrItems[$last]['class'] . ' last');
+			
+			//ermitteln ob ein aktives Untermenü besteht		
+			foreach($arrItems as $k => $item)
+			{
+				if($item['itemtype'] != 'page' && $item['isActive']) $this->isSubActive = true; 			
+			}
 		}
 
 		$objTemplate->items = $arrItems;


### PR DESCRIPTION
es wird ermittelt ob ein aktiver Unterpunkt gefunden wurde wenn ja, wird die Eigenschaft isSubActive auf true gesetzt. So kann es von "yNavigationPageProvider" weiter verwendet werden.

Ist vielleicht nicht die edelste Lösung, sie funktioniert aber.
